### PR TITLE
Fix exception when no 'Set-Cookie' headers

### DIFF
--- a/src/Search/SearchRequest.php
+++ b/src/Search/SearchRequest.php
@@ -122,9 +122,8 @@ class SearchRequest
 
     private function getRefreshedCookieHeader(ClientException $exception): string
     {
-        return (string)explode(
-            ';',
-            $exception->getResponse()->getHeaders()['Set-Cookie'][0] ?? []
-        )[0];
+        return $exception->getResponse() && isset($exception->getResponse()->getHeaders()['Set-Cookie'][0])
+            ? (string)explode(';', $exception->getResponse()->getHeaders()['Set-Cookie'][0])[0]
+            : '';
     }
 }


### PR DESCRIPTION
An empty array is passed to the explode function when there is no 'Set-Cookie' header in the response.